### PR TITLE
Remove terminator from protocol file.

### DIFF
--- a/Keithley2400Sup/Keithley2400.proto
+++ b/Keithley2400Sup/Keithley2400.proto
@@ -16,7 +16,6 @@
 # General Settings
 ##################################################
 
-Terminator = "\r\n";
 ReplyTimeout = 1000;
 
 


### PR DESCRIPTION
Use setOutputEos and setInputEos from st.cmd instead of in protocol file for 
https://github.com/ISISComputingGroup/IBEX/issues/2695

See PR at https://github.com/ISISComputingGroup/EPICS-ioc/pull/190 for details of acceptance criteria and how to test.