### PR TITLE
Change protocol to allow for model 2410

### DIFF
--- a/Keithley2400Sup/Keithley2400.proto
+++ b/Keithley2400Sup/Keithley2400.proto
@@ -33,14 +33,14 @@ getID {
 # /// Read the voltage from the data string. Format is %g (V), %g (I), %g (R), %g (Timestamp), %g (Status)
 get_V {
    ExtraInput = Ignore;
-   out ":READ?";
+   out "\$1";
    in "%g,%*g,%*g";
 }
 
 # /// Read the current from the data string. Format is %g (V), %g (I), %g (R), %g (Timestamp), %g (Status)
 get_I {
    ExtraInput = Ignore;
-   out ":READ?";
+   out "\$1";
    in "%*g,%g,%*g";
 }
 
@@ -61,7 +61,7 @@ get_I_COMPLIANCE {
 # /// Read the resistance from the data string. Format is %g (V), %g (I), %g (R), %g (Timestamp), %g (Status)
 get_R {
    ExtraInput = Ignore;
-   out ":READ?";
+   out "\$1";
    in "%*g,%*g,%g";
 }
 


### PR DESCRIPTION
Allow protocol commands for get_V, get_I and get_R to be set via macro

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/6534